### PR TITLE
Fix command available check for windows

### DIFF
--- a/audioop/common.go
+++ b/audioop/common.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"math"
 )
+func GetSamples(cp []byte, size int) ([]int32, error) {
+	return getSamples(cp, size)
+}
 
 func getSamples(cp []byte, size int) ([]int32, error) {
 	read, err := getReadBinaryFunc(size)

--- a/converter/utils.go
+++ b/converter/utils.go
@@ -2,7 +2,7 @@ package converter
 
 import (
 	"fmt"
-
+	"runtime"
 	"os/exec"
 )
 
@@ -15,7 +15,11 @@ func GetEncoderName() string {
 }
 
 func IsCommandAvailable(name string) bool {
-	cmd := exec.Command("which", name)
+	checkExistCmd := "which"
+	if runtime.GOOS == "windows" {
+		checkExistCmd = "where"
+	}
+	cmd := exec.Command(checkExistCmd, name)
 	if err := cmd.Run(); err != nil {
 		return false
 	}


### PR DESCRIPTION
Because the "where" cmd is not available on windows, so it will always show "ffmpeg" not found.